### PR TITLE
add special cases for +/-1 elsewhere

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -939,6 +939,10 @@ class Float(Number):
 
     @_sympifyit('other', NotImplemented)
     def __mul__(self, other):
+        if other is S.One:
+            return self or S.Zero
+        if other is S.NegativeOne:
+            return -self
         if isinstance(other, Number):
             rhs, prec = other._as_mpf_op(self._prec)
             return Float._new(mlib.mpf_mul(self._mpf_, rhs, prec, rnd), prec)
@@ -946,6 +950,10 @@ class Float(Number):
 
     @_sympifyit('other', NotImplemented)
     def __div__(self, other):
+        if other is S.One:
+            return self or S.Zero
+        if other is S.NegativeOne:
+            return -self
         if isinstance(other, Number) and other != 0:
             rhs, prec = other._as_mpf_op(self._prec)
             return Float._new(mlib.mpf_div(self._mpf_, rhs, prec, rnd), prec)
@@ -1388,11 +1396,11 @@ class Rational(Number):
 
     @_sympifyit('other', NotImplemented)
     def __mul__(self, other):
-        if self is S.One:
-            return other or S.Zero
-        if other is S.One:
-            return self or S.Zero
         if isinstance(other, Rational):
+            if other is S.One:
+                return self
+            if other is S.NegativeOne:
+                return -self
             return Rational(self.p*other.p, self.q*other.q)
         elif isinstance(other, Float):
             return other*self
@@ -1402,6 +1410,10 @@ class Rational(Number):
     @_sympifyit('other', NotImplemented)
     def __div__(self, other):
         if isinstance(other, Rational):
+            if other is S.One:
+                return self
+            if other is S.NegativeOne:
+                return -self
             if self.p and other.p == S.Zero:
                 return S.ComplexInfinity
             else:
@@ -2291,6 +2303,10 @@ class One(with_metaclass(Singleton, IntegerConstant)):
     def __neg__():
         return S.NegativeOne
 
+    @_sympifyit('other', NotImplemented)
+    def __mul__(self, other):
+        return other or S.Zero
+
     def _eval_power(self, expt):
         return self
 
@@ -2342,6 +2358,10 @@ class NegativeOne(with_metaclass(Singleton, IntegerConstant)):
     @staticmethod
     def __neg__():
         return S.One
+
+    @_sympifyit('other', NotImplemented)
+    def __mul__(self, other):
+        return -other
 
     def _eval_power(self, expt):
         if expt.is_odd:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -231,6 +231,8 @@ class Pow(Expr):
     def _eval_power(self, other):
         from sympy import Abs, arg, exp, floor, im, log, re, sign, refine
         b, e = self.as_base_exp()
+        if other is S.NegativeOne:
+            return Pow(b, -e)
         if b is S.NaN:
             return (b**e)**other  # let __new__ handle it
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1892,3 +1892,26 @@ def test_issue_8247_8354():
 def test_Add_is_zero():
     x, y = symbols('x y', zero=True)
     assert (x + y).is_zero
+
+
+def test_special_case_ones():
+    z = S('0.0')
+    # Python controls these
+    assert 1*z == z
+    assert -1*z == z
+    # SymPy controls these
+    assert -S('0.0') is S.Zero
+    assert S(1)*z is S.Zero
+    assert S(-1)*z is S.Zero
+    assert z*S(1) is S.Zero
+    assert z*S(-1) is S.Zero
+    assert z/S(1) is S.Zero
+    assert z/S(-1) is S.Zero
+
+    h = S.Half
+    assert S(1)*h is S.Half
+    assert S(-1)*h == -S.Half
+    assert h*S(1) is S.Half
+    assert h*S(-1) == -S.Half
+    assert h/S(1) is S.Half
+    assert h/S(-1) == -S.Half

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1515,6 +1515,9 @@ def test_nth_linear_constant_coeff_homogeneous_rootof():
         C3*exp(x*rootof(x**5 + 11*x - 2, 2)) +
         C4*exp(x*rootof(x**5 + 11*x - 2, 3)) +
         C5*exp(x*rootof(x**5 + 11*x - 2, 4)))
+    print()
+    print(dsolve(eq).args)
+    print(sol.args)
     assert dsolve(eq) == sol
 
 

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1510,14 +1510,11 @@ def test_nth_linear_constant_coeff_homogeneous():
 def test_nth_linear_constant_coeff_homogeneous_rootof():
     eq = f(x).diff(x, 5) + 11*f(x).diff(x) - 2*f(x)
     sol = Eq(f(x),
-        C1*exp(x*rootof(x**5 + 11*x - 2, 0)) +
-        C2*exp(x*rootof(x**5 + 11*x - 2, 1)) +
-        C3*exp(x*rootof(x**5 + 11*x - 2, 2)) +
-        C4*exp(x*rootof(x**5 + 11*x - 2, 3)) +
-        C5*exp(x*rootof(x**5 + 11*x - 2, 4)))
-    print()
-    print(dsolve(eq).args)
-    print(sol.args)
+        C1*exp(x*rootof(x**5 + 11*x - 2, 2)) +
+        C2*exp(x*rootof(x**5 + 11*x - 2, 3)) +
+        C3*exp(x*rootof(x**5 + 11*x - 2, 4)) +
+        C4*exp(x*rootof(x**5 + 11*x - 2, 0)) +
+        C5*exp(x*rootof(x**5 + 11*x - 2, 1)))
     assert dsolve(eq) == sol
 
 


### PR DESCRIPTION
Not sure why tests don't fail here.

Modifications include moving code to `class One` and `class NegativeOne` since that will, then, directly handle those cases. I also added a similar mod to `Numbers.__mul__` and added tests testing the `0.0 -> 0` cases.
